### PR TITLE
removed fmt from pipeline as not working as intended

### DIFF
--- a/.github/workflows/terraform-deployment.yml
+++ b/.github/workflows/terraform-deployment.yml
@@ -21,10 +21,6 @@ jobs:
       - name: Terraform setup
         uses: hashicorp/setup-terraform@v1
 
-      - name: Terraform Format
-        id: fmt
-        run: terraform fmt -check
-
       - name: Terraform Init
         id: init
         run: terraform init


### PR DESCRIPTION
When we push terraform, make sure we run terraform fmt on our local machines to format it properly.